### PR TITLE
Fix spelling (invertor -> inverter)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -3,13 +3,13 @@
     "en": "performance boost (disable meter2,3 and batt2) takes 4 seconds to measure, polling back to 30 sec, added import control action plus flow, control min import even with battery"
   },   
   "2.1.6": {
-    "en": "added invertor and meter1 current caps"
+    "en": "added inverter and meter1 current caps"
   },    
   "2.1.5": {
     "en": "active power, export limit control for batt or meters (action + flows)"
   },   
   "2.0.13": {
-    "en": "adding owncomsumption for battery invertors, export, import & consumption triggers"
+    "en": "adding owncomsumption for battery inverters, export, import & consumption triggers"
   },    
   "2.0.12": {
     "en": "better error handling"

--- a/.homeycompose/capabilities/invertorstatus.json
+++ b/.homeycompose/capabilities/invertorstatus.json
@@ -1,7 +1,7 @@
 {
     "type": "enum",
     "title": {
-        "en": "Invertor status"
+        "en": "Inverter status"
     },
     "getable": true,
     "setable": false,

--- a/.homeycompose/flow/conditions/changedStatus.json
+++ b/.homeycompose/flow/conditions/changedStatus.json
@@ -1,12 +1,12 @@
 {
     "title": {
-        "en": "Invertor status is"
+        "en": "Inverter status is"
     },
     "titleFormatted": {
-        "en": "Invertor status is [[argument_main]]"
+        "en": "Inverter status is [[argument_main]]"
     },    
     "hint": {
-        "en": "Invertor status"
+        "en": "Inverter status"
     },
     "args": [
         {

--- a/app.json
+++ b/app.json
@@ -234,13 +234,13 @@
     "conditions": [
       {
         "title": {
-          "en": "Invertor status is"
+          "en": "Inverter status is"
         },
         "titleFormatted": {
-          "en": "Invertor status is [[argument_main]]"
+          "en": "Inverter status is [[argument_main]]"
         },
         "hint": {
-          "en": "Invertor status"
+          "en": "Inverter status"
         },
         "args": [
           {
@@ -314,10 +314,10 @@
       {
         "id": "solarcharge",
         "title": {
-          "en": "Invertor !{{is|isn't}} higher than"
+          "en": "Inverter !{{is|isn't}} higher than"
         },
         "hint": {
-          "en": "Invertor charging in watts"
+          "en": "Inverter charging in watts"
         },
         "args": [
           {
@@ -434,10 +434,10 @@
       {
         "id": "solarbattcharge",
         "title": {
-          "en": "Invertor + Battery !{{is|isn't}} higher than"
+          "en": "Inverter + Battery !{{is|isn't}} higher than"
         },
         "hint": {
-          "en": "Invertor plus battery charging in watts"
+          "en": "Inverter plus battery charging in watts"
         },
         "args": [
           {
@@ -939,7 +939,7 @@
   "drivers": [
     {
       "name": {
-        "en": "Invertor"
+        "en": "Inverter"
       },
       "class": "solarpanel",
       "energy": {
@@ -1063,7 +1063,7 @@
     },
     {
       "name": {
-        "en": "Invertor with storedge"
+        "en": "Inverter with storedge"
       },
       "class": "solarpanel",
       "energy": {
@@ -1482,7 +1482,7 @@
     "invertorstatus": {
       "type": "enum",
       "title": {
-        "en": "Invertor status"
+        "en": "Inverter status"
       },
       "getable": true,
       "setable": false,

--- a/drivers/invertor/device.ts
+++ b/drivers/invertor/device.ts
@@ -20,7 +20,7 @@ class MySolaredgeDevice extends Solaredge {
     this.pollInvertor();
 
     this.timer = this.homey.setInterval(() => {
-      // poll device state from invertor
+      // poll device state from inverter
       this.pollInvertor();
     }, RETRY_INTERVAL);
 

--- a/drivers/invertor/driver.compose.json
+++ b/drivers/invertor/driver.compose.json
@@ -1,6 +1,6 @@
 {
   "name": {
-    "en": "Invertor"
+    "en": "Inverter"
   },
   "class": "solarpanel",
   "energy": {

--- a/drivers/invertor/driver.flow.compose.json
+++ b/drivers/invertor/driver.flow.compose.json
@@ -5,10 +5,10 @@
         {
             "id": "solarcharge",
             "title": {
-                "en": "Invertor !{{is|isn't}} higher than"
+                "en": "Inverter !{{is|isn't}} higher than"
             },
             "hint": {
-                "en": "Invertor charging in watts"
+                "en": "Inverter charging in watts"
             },
             "args": [
                 {

--- a/drivers/invertorwithbatt/device.ts
+++ b/drivers/invertorwithbatt/device.ts
@@ -24,7 +24,7 @@ class MySolaredgeBatteryDevice extends Solaredge {
     this.pollInvertor();
 
     this.timer = this.homey.setInterval(() => {
-      // poll device state from invertor
+      // poll device state from inverter
       this.pollInvertor();
     }, RETRY_INTERVAL);
 

--- a/drivers/invertorwithbatt/driver.compose.json
+++ b/drivers/invertorwithbatt/driver.compose.json
@@ -1,6 +1,6 @@
 {
   "name": {
-    "en": "Invertor with storedge"
+    "en": "Inverter with storedge"
   },
   "class": "solarpanel",
   "energy": {

--- a/drivers/invertorwithbatt/driver.flow.compose.json
+++ b/drivers/invertorwithbatt/driver.flow.compose.json
@@ -186,10 +186,10 @@
     {
       "id": "solarbattcharge",
       "title": {
-        "en": "Invertor + Battery !{{is|isn't}} higher than"
+        "en": "Inverter + Battery !{{is|isn't}} higher than"
       },
       "hint": {
-        "en": "Invertor plus battery charging in watts"
+        "en": "Inverter plus battery charging in watts"
       },
       "args": [
         {


### PR DESCRIPTION
I propose to change "invertor" to the correct English term "inverter" in all texts. I am not sure if changing the variables/functions etc is a good idea, as I am not familiar with how Homey apps work yet. Will it break stored settings or anything else? If there are no breaking changes I suggest to change all instances of "invertor" to "inverter" in the code. 