### PR TITLE
Expose n phases voltage

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,12 +1,10 @@
 {
   "id": "solaredge.modbus",
-  "version": "3.0.46",
+  "version": "3.0.47",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "brandColor": "#df001c",
-  "platforms": [
-    "local"
-  ],
+  "platforms": ["local"],
   "name": {
     "en": "SolarEdge + Growatt TCP modbus"
   },
@@ -14,32 +12,18 @@
     "en": "Monitor SolarEdge + Growatt inverters over TCP modbus protocol",
     "de": "Überwache SolarEdge- und Growatt-Wechselrichter über das TCP-Modbus-Protokoll"
   },
-  "category": [
-    "energy"
-  ],
+  "category": ["energy"],
   "tags": {
-    "en": [
-      "solaredge",
-      "growatt",      
-      "inverter",
-      "solar",
-      "modbus"
-    ],
+    "en": ["solaredge", "growatt", "inverter", "solar", "modbus"],
     "nl": [
       "solaredge",
-      "growatt",      
+      "growatt",
       "omvormer",
       "zonnepanelen",
       "modbus",
-      "solar"      
+      "solar"
     ],
-    "de": [
-      "solaredge",
-      "growatt",
-      "wechselrichter",
-      "solar",
-      "modbus"
-    ]
+    "de": ["solaredge", "growatt", "wechselrichter", "solar", "modbus"]
   },
   "bugs": {
     "url": "https://github.com/biemond/solaredge.modbus/issues"

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "solaredge.modbus",
-  "version": "3.0.46",
+  "version": "3.0.47",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "brandColor": "#df001c",
@@ -2504,6 +2504,9 @@
         "measure_voltage.phase1",
         "measure_voltage.phase2",
         "measure_voltage.phase3",
+        "measure_voltage.phase1n",
+        "measure_voltage.phase2n",
+        "measure_voltage.phase3n",
         "measure_temperature.invertor",
         "invertorstatus",
         "meter_power",
@@ -2558,6 +2561,24 @@
           "title": {
             "en": "Voltage phase3",
             "de": "Spannung Phase 3"
+          }
+        },
+        "measure_voltage.phase1n": {
+          "title": {
+            "en": "Voltage phase1n",
+            "de": "Spannung Phase 1n"
+          }
+        },
+        "measure_voltage.phase2n": {
+          "title": {
+            "en": "Voltage phase2n",
+            "de": "Spannung Phase 2n"
+          }
+        },
+        "measure_voltage.phase3n": {
+          "title": {
+            "en": "Voltage phase3n",
+            "de": "Spannung Phase 3n"
           }
         },
         "measure_temperature.invertor": {

--- a/drivers/invertor/device.ts
+++ b/drivers/invertor/device.ts
@@ -73,6 +73,16 @@ class MySolaredgeDevice extends Solaredge {
       await this.addCapability('measure_voltage.phase3');
     } 
 
+    if (this.hasCapability('measure_voltage.phase1n') === false) {
+      await this.addCapability('measure_voltage.phase1n');
+    }
+    if (this.hasCapability('measure_voltage.phase2n') === false) {
+      await this.addCapability('measure_voltage.phase2n');
+    }
+    if (this.hasCapability('measure_voltage.phase3n') === false) {
+      await this.addCapability('measure_voltage.phase3n');
+    } 
+
   }
 
   /**

--- a/drivers/invertor/driver.compose.json
+++ b/drivers/invertor/driver.compose.json
@@ -5,9 +5,7 @@
   },
   "class": "solarpanel",
   "energy": {
-    "batteries": [
-      "OTHER"
-    ]
+    "batteries": ["OTHER"]
   },
   "capabilities": [
     "measure_power",
@@ -17,7 +15,10 @@
     "measure_current.phase3",
     "measure_voltage.phase1",
     "measure_voltage.phase2",
-    "measure_voltage.phase3",  
+    "measure_voltage.phase3",
+    "measure_voltage.phase1n",
+    "measure_voltage.phase2n",
+    "measure_voltage.phase3n",
     "measure_temperature.invertor",
     "invertorstatus",
     "meter_power",
@@ -73,7 +74,25 @@
         "en": "Voltage phase3",
         "de": "Spannung Phase 3"
       }
-    },  
+    },
+    "measure_voltage.phase1n": {
+      "title": {
+        "en": "Voltage phase1n",
+        "de": "Spannung Phase 1n"
+      }
+    },
+    "measure_voltage.phase2n": {
+      "title": {
+        "en": "Voltage phase2n",
+        "de": "Spannung Phase 2n"
+      }
+    },
+    "measure_voltage.phase3n": {
+      "title": {
+        "en": "Voltage phase3n",
+        "de": "Spannung Phase 3n"
+      }
+    },
     "measure_temperature.invertor": {
       "title": {
         "en": "Heatsink temperature",
@@ -100,12 +119,8 @@
       "icon": "/assets/total_yield.svg"
     }
   },
-  "platforms": [
-    "local"
-  ],
-  "connectivity": [
-    "lan"
-  ],
+  "platforms": ["local"],
+  "connectivity": ["lan"],
   "images": {
     "small": "{{driverAssetsPath}}/images/small.jpg",
     "large": "{{driverAssetsPath}}/images/large.jpg"

--- a/drivers/solaredge.ts
+++ b/drivers/solaredge.ts
@@ -298,6 +298,22 @@ export class Solaredge extends Homey.Device {
                 this.setCapabilityValue('measure_voltage.phase3', voltagel3);
             }
 
+            if (this.validResultRecord(result['l1n_voltage']) && this.validResultScaleRecord(result['l1n_voltage']) && result['l1n_voltage'].value != '-1') {
+                this.addCapability('measure_voltage.phase1n');
+                var voltagel1n = Number(result['l1n_voltage'].value) * (Math.pow(10,  Number(result['l1n_voltage'].scale)));
+                this.setCapabilityValue('measure_voltage.phase1n', voltagel1n);
+            }
+            if (this.validResultRecord(result['l2n_voltage']) && this.validResultScaleRecord(result['l2n_voltage']) && result['l2n_voltage'].value != '-1') {
+                this.addCapability('measure_voltage.phase2n');
+                var voltagel2n = Number(result['l2n_voltage'].value) * (Math.pow(10,  Number(result['l2n_voltage'].scale)));
+                this.setCapabilityValue('measure_voltage.phase2n', voltagel2n);
+            }
+            if (this.validResultRecord(result['l3n_voltage']) && this.validResultScaleRecord(result['l3n_voltage']) && result['l3n_voltage'].value != '-1') {
+                this.addCapability('measure_voltage.phase3n');
+                var voltagel3n = Number(result['l3n_voltage'].value) * (Math.pow(10,  Number(result['l3n_voltage'].scale)));
+                this.setCapabilityValue('measure_voltage.phase3n', voltagel3n);
+            }
+
             let tz = this.homey.clock.getTimezone();
             var now = new Date().toLocaleString(this.homey.i18n.getLanguage(),
                 {


### PR DESCRIPTION
I propose to add n phases voltage (L1-N, L2-N, L3-N) to SolarEdge inverter device. Something kinda similar was added recently to SolarEdge with battery device and I'm thinking that having this device capability may be very useful.

![image](https://github.com/biemond/solaredge.modbus/assets/46241721/ddbc20f5-4069-4ea5-8acf-a93bb7970843)
