### PR TITLE
Fix visibility of inverted conditions in advanced flow

### DIFF
--- a/.homeycompose/flow/conditions/changedStatus.json
+++ b/.homeycompose/flow/conditions/changedStatus.json
@@ -1,11 +1,11 @@
 {
   "title": {
-    "en": "Inverter status is",
-    "de": "Status des Wechselrichters ist"
+    "en": "Inverter status !{{is|is not}}",
+    "de": "Status des Wechselrichters !{{ist|ist nicht}}"
   },
   "titleFormatted": {
-    "en": "Inverter status is [[argument_main]]",
-    "de": "Status des Wechselrichters ist [[argument_main]]"
+    "en": "Inverter status !{{is|is not}} [[argument_main]]",
+    "de": "Status des Wechselrichters !{{ist|ist nicht}} [[argument_main]]"
   },
   "hint": {
     "en": "Inverter status",

--- a/.homeycompose/flow/conditions/exportLimit.json
+++ b/.homeycompose/flow/conditions/exportLimit.json
@@ -1,13 +1,13 @@
 {
   "title": {
-    "en": "Export Limit is",
-    "nl": "Export limiet is",
-    "de": "Exportlimit ist"
+    "en": "Export Limit !{{is|is not}}",
+    "nl": "Export limiet !{{is|is niet}}",
+    "de": "Exportlimit !{{ist|ist nicht}}"
   },
   "titleFormatted": {
-    "en": "Export limit is [[exportlimit]]",
-    "nl": "Export limiet is [[exportlimit]]",
-    "de": "Exportlimit ist [[exportlimit]]"
+    "en": "Export limit !{{is|is not}} [[exportlimit]]",
+    "nl": "Export limiet !{{is|is niet}} [[exportlimit]]",
+    "de": "Exportlimit !{{ist|ist nicht}} [[exportlimit]]"
   },
   "hint": {
     "en": "Whether export limit is enabled or disabled",

--- a/.homeycompose/flow/conditions/priorityMode.json
+++ b/.homeycompose/flow/conditions/priorityMode.json
@@ -1,13 +1,13 @@
 {
   "title": {
-    "en": "Inverter priority is",
-    "nl": "Omvormerprioriteit is",
-    "de": "Wechselrichter-Priorität ist"
+    "en": "Inverter priority !{{is|is not}}",
+    "nl": "Omvormerprioriteit !{{is|is niet}}",
+    "de": "Wechselrichter-Priorität !{{ist|ist nicht}}"
   },
   "titleFormatted": {
-    "en": "Inverter priority is [[priority]]",
-    "nl": "Omvormerprioriteit is [[priority]]",
-    "de": "Wechselrichter-Priorität ist [[priority]]"
+    "en": "Inverter priority !{{is|is not}} [[priority]]",
+    "nl": "Omvormerprioriteit !{{is|is niet}} [[priority]]",
+    "de": "Wechselrichter-Priorität !{{ist|ist nicht}} [[priority]]"
   },
   "hint": {
     "en": "Inverter priority",


### PR DESCRIPTION
When conditions are inverted it can change the title. For the advanced Flow this is the only way to see if condition is inverted.