### PR TITLE
Update activepowerlimit2.json

### DIFF
--- a/.homeycompose/capabilities/activepowerlimit2.json
+++ b/.homeycompose/capabilities/activepowerlimit2.json
@@ -3,7 +3,7 @@
   "title": {
     "en": "Active power limit",
     "de": "Aktive Leistungsbeschränkung",
-    "sv": "Aktiv Effektbegränsning"
+    "sv": "Utmatad effekt (AC)"
   },
   "getable": true,
   "setable": false,


### PR DESCRIPTION
I understand that this capability is also used in other brands, so I assume it should be copied to Sungrow and used locally in order to be able to change the variable names. But for now, here is only a swe translation change