### PR TITLE
Fix time slot end time

### DIFF
--- a/drivers/growattwithbatt/device.ts
+++ b/drivers/growattwithbatt/device.ts
@@ -536,7 +536,7 @@ class MyGrowattBattery extends Growatt {
     if (end.date() !== now.date()) {
       endTime = 5947; // 23:59
     } else {
-      endTime = (end.hours() << 8) + end.minutes();
+      endTime = (end.hours() << 8) + (end.minutes() - 1);
     }
 
     socket.on('connect', () => {


### PR DESCRIPTION
This is very tiny fix for a quite annoying bug. It appears in the situation when I create the following flows:
at xx:00 set battery first for 1/4 hour
at xx:15 set grid first for 1/4 hour
What happens than BF is set for interval xx:00-xx:15 and than setting GF xx:15-xx:30 is not working because BF and GF intervals overlap for 1 minute.
With this simple fix it will do BF xx:00-xx:14 and than GF xx:15-xx:29, so no overlapping time slots anymore 