### PR TITLE
fix inverter brand when pairing Solaredge inverter (German locale)

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1,6 +1,6 @@
 {
   "pair": {
-    "title": "Kostal Wechselrichter hinzufügen",
+    "title": "Solaredge Wechselrichter hinzufügen",
     "title_growatt": "Growatt Wechselrichter hinzufügen",
     "title_wattsonic": "Wattsonic Wechselrichter hinzufügen",
     "title_solax": "SOLAX Wechselrichter hinzufügen",


### PR DESCRIPTION
Comparing en.json I've just replaced the string "Kostal" with "Solaredge" to fix the UI.