### PR TITLE
Added Power Limit slider to Growatt TLS

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -133,5 +133,8 @@
   },
   "3.0.226": {
     "en": "Updated Growatt TLS"
+  },
+  "3.0.227": {
+    "en": "Added Power Limit slider to Growatt TLS"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,7 +1,7 @@
 {
   "id": "solaredge.modbus",
-  "version": "3.0.226",
-  "compatibility": ">=5.0.0",
+  "version": "3.0.227",
+  "compatibility": ">=12.13.0",
   "sdk": 3,
   "brandColor": "#df001c",
   "platforms": [

--- a/.homeycompose/capabilities/exportcapacity.json
+++ b/.homeycompose/capabilities/exportcapacity.json
@@ -1,29 +1,29 @@
 {
   "type": "number",
   "title": {
-    "en": "Output capacity %",
-    "da": "Udgangskapacitet %",
-    "de": "Ausgangskapazität %",
-    "es": "Capacidad de salida %",
-    "fr": "Capacité de sortie %",
-    "it": "Capacità di uscita %",
-    "ko": "출력 용량 %",
-    "nl": "Uitgangscapaciteit %",
-    "no": "Utgangskapasitet %",
-    "pl": "Pojemność wyjściowa %",
-    "sv": "Uteffektkapacitet %"
+    "en": "Power Limit",
+    "da": "Effektgrænse",
+    "de": "Leistungsgrenze",
+    "es": "Límite de potencia",
+    "fr": "Limite de puissance",
+    "it": "Limite di potenza",
+    "ko": "전력 한도",
+    "nl": "Vermogenslimiet",
+    "no": "Effektgrense",
+    "pl": "Limit mocy",
+    "sv": "Effektgräns"
   },
   "getable": true,
   "setable": false,
   "uiComponent": "sensor",
   "uiQuickAction": true,
-  "insights": true,
+  "insights": false,
   "icon": "/assets/limit.svg",
   "units": {
-    "en": "%"
+    "en": "W"
   },
   "decimals": 0,
   "min": 0,
-  "max": 100,
+  "max": 6000,
   "step": 1
 }

--- a/.homeycompose/flow/actions/exportcapacity.json
+++ b/.homeycompose/flow/actions/exportcapacity.json
@@ -1,4 +1,5 @@
 {
+  "deprecated": true,
   "title": {
     "en": "Set output capacity",
     "da": "Indstil udgangskapacitet",

--- a/.homeycompose/flow/actions/timesync.json
+++ b/.homeycompose/flow/actions/timesync.json
@@ -1,12 +1,12 @@
 {
   "title": {
-    "en": "Sync Invertor Clock",
+    "en": "Sync Inverter Clock",
     "nl": "Synchroniseer omvormerklok",
     "de": "Synchronisiere Wechselrichteruhr",
     "sv": "Synkronisera växelriktarens klocka"
   },
   "titleFormatted": {
-    "en": "Sync Invertor Clock, including date: [[syncdate]]",
+    "en": "Sync Inverter Clock, including date: [[syncdate]]",
     "nl": "Synchroniseer omvormerklok, inclusief datum: [[syncdate]]",
     "de": "Synchronisiere Wechselrichteruhr, einschließlich Datum: [[syncdate]]",
     "sv": "Synkronisera växelriktarens klocka, inkl. datum: [[syncdate]]"

--- a/app.json
+++ b/app.json
@@ -1,8 +1,8 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "solaredge.modbus",
-  "version": "3.0.226",
-  "compatibility": ">=5.0.0",
+  "version": "3.0.227",
+  "compatibility": ">=12.13.0",
   "sdk": 3,
   "brandColor": "#df001c",
   "platforms": [
@@ -2049,6 +2049,7 @@
         "id": "battery_minimum_capacity"
       },
       {
+        "deprecated": true,
         "title": {
           "en": "Set output capacity",
           "da": "Indstil udgangskapacitet",
@@ -2684,13 +2685,13 @@
       },
       {
         "title": {
-          "en": "Sync Invertor Clock",
+          "en": "Sync Inverter Clock",
           "nl": "Synchroniseer omvormerklok",
           "de": "Synchronisiere Wechselrichteruhr",
           "sv": "Synkronisera växelriktarens klocka"
         },
         "titleFormatted": {
-          "en": "Sync Invertor Clock, including date: [[syncdate]]",
+          "en": "Sync Inverter Clock, including date: [[syncdate]]",
           "nl": "Synchroniseer omvormerklok, inclusief datum: [[syncdate]]",
           "de": "Synchronisiere Wechselrichteruhr, einschließlich Datum: [[syncdate]]",
           "sv": "Synkronisera växelriktarens klocka, inkl. datum: [[syncdate]]"
@@ -5443,6 +5444,7 @@
         "exportlimitenabled",
         "exportlimitpowerrate",
         "exportcapacity",
+        "target_power",
         "growattstatus"
       ],
       "capabilitiesOptions": {
@@ -11351,30 +11353,30 @@
     "exportcapacity": {
       "type": "number",
       "title": {
-        "en": "Output capacity %",
-        "da": "Udgangskapacitet %",
-        "de": "Ausgangskapazität %",
-        "es": "Capacidad de salida %",
-        "fr": "Capacité de sortie %",
-        "it": "Capacità di uscita %",
-        "ko": "출력 용량 %",
-        "nl": "Uitgangscapaciteit %",
-        "no": "Utgangskapasitet %",
-        "pl": "Pojemność wyjściowa %",
-        "sv": "Uteffektkapacitet %"
+        "en": "Power Limit",
+        "da": "Effektgrænse",
+        "de": "Leistungsgrenze",
+        "es": "Límite de potencia",
+        "fr": "Limite de puissance",
+        "it": "Limite di potenza",
+        "ko": "전력 한도",
+        "nl": "Vermogenslimiet",
+        "no": "Effektgrense",
+        "pl": "Limit mocy",
+        "sv": "Effektgräns"
       },
       "getable": true,
       "setable": false,
       "uiComponent": "sensor",
       "uiQuickAction": true,
-      "insights": true,
+      "insights": false,
       "icon": "/assets/limit.svg",
       "units": {
-        "en": "%"
+        "en": "W"
       },
       "decimals": 0,
       "min": 0,
-      "max": 100,
+      "max": 6000,
       "step": 1
     },
     "exportcontrollimitmode": {

--- a/drivers/growatt.ts
+++ b/drivers/growatt.ts
@@ -600,7 +600,7 @@ export class Growatt extends Homey.Device {
     },
     {
       resultKey: 'activePRate',
-      capabilities: ['exportcapacity'],
+      capabilities: ['target_power'],
       valid: (data) => this.isValidNumberInRange(data.value, 0, 100),
       transform: (data) => Number(data.value),
     },

--- a/drivers/growatt_tls/device.ts
+++ b/drivers/growatt_tls/device.ts
@@ -20,41 +20,6 @@ class MyGrowattTL3sDevice extends Growatt {
     this.log(`device name id ${name}`);
     this.log(`device name ${this.getName()}`);
 
-    /*
-   const limitCondition = this.homey.flow.getConditionCard('exportLimit');
-    limitCondition.registerRunListener(async (args, state) => {
-      const result = Number(await args.device.getCapabilityValue('exportlimitenabled')) === Number(args.exportlimit);
-      return result;
-    });
-
-    const exportEnabledAction = this.homey.flow.getActionCard('exportlimitenabled');
-    exportEnabledAction.registerRunListener(async (args, state) => {
-      const smartmeter = this.getSetting('smartMeter')
-        if (!smartmeter) {
-          throw new Error(
-            'No Modbus Smart Meter is configured.\n\nYou can enable it in the devices Advanced Settings.\nImportant: Do NOT enable the seting when no Modbus Smart Meter is connected.'
-          );
-        }
-      await this.updateControl('exportlimitenabled', Number(args.mode));
-    });
-
-    const exportlimitpowerrateAction = this.homey.flow.getActionCard('exportlimitpowerrate');
-    exportlimitpowerrateAction.registerRunListener(async (args, state) => {
-      const smartmeter = this.getSetting('smartMeter')
-        if (!smartmeter) {
-          throw new Error(
-            'No Modbus Smart Meter is configured.\n\nYou can enable it in the devices Advanced Settings.\nImportant: Do NOT enable the seting when no Modbus Smart Meter is connected.'
-          );
-        }          
-      await this.updateControl('exportlimitpowerrate', args.percentage);
-    });
-
-    const exportcapacityAction = this.homey.flow.getActionCard('exportcapacity');
-    exportcapacityAction.registerRunListener(async (args, state) => {        
-      await this.updateControl('exportcapacity', args.percentage);
-    });
-    */
-
     // remove unexpected capabilities 
     if (this.hasCapability('growatt_onoff')) {
       await this.removeCapability('growatt_onoff');
@@ -91,7 +56,7 @@ class MyGrowattTL3sDevice extends Growatt {
     }    
     // end
 
-    if (this.hasCapability('onoff') === true) {
+    if (this.hasCapability('onoff')) {
       await this.removeCapability('onoff');
     }
 
@@ -105,6 +70,32 @@ class MyGrowattTL3sDevice extends Growatt {
 
     if (this.hasCapability('exportlimitpowerrate') === false) {
       await this.addCapability('exportlimitpowerrate');
+    }
+
+    if (this.hasCapability('target_power') === false) {
+      await this.addCapability('target_power');
+    }
+
+    const maxpeakpower = Number(this.getSetting('maxpeakpower'));
+    
+    await this.setCapabilityOptions('target_power', { min: 0, max: this.getEffectiveMaxPower() });
+    await this.setCapabilityOptions('exportcapacity', { max: this.getEffectiveMaxPower() });
+    
+    if (maxpeakpower <= 0) {
+      await this.homey.notifications.createNotification({ excerpt: 'Growatt TLS: Max peak power is not configured. Please set it in the device settings for accurate target power control.' });
+    }
+
+    this.registerCapabilityListener('target_power', async (value) => {
+      if (maxpeakpower <= 0) {
+        throw new Error('Max peak power is not configured. Please set it in the device settings.');
+      }
+      const percentage = Math.round((value / maxpeakpower) * 100);
+      await this.updateControl('target_power', percentage);
+      await this.setCapabilityValue('exportcapacity', value);  
+    });
+
+    if (this.getCapabilityValue('target_power') === null) {
+      await this.setCapabilityValue('target_power', 0);
     }
 
     this.pollInvertor().catch(this.error);
@@ -157,7 +148,12 @@ class MyGrowattTL3sDevice extends Growatt {
     newSettings: { [key: string]: string };
     changedKeys: string[];
   }): Promise<string | void> {
-    this.log('MyGrowattBattery settings were changed');
+    this.log('Growatt TLS settings were changed');
+    if (changedKeys.includes('maxpeakpower')) {
+      const max = Number(newSettings.maxpeakpower) || 6000;
+      await this.setCapabilityOptions('target_power', { min: 0, max });
+      await this.setCapabilityOptions('exportcapacity', { max });
+    }    
   }
 
   /**
@@ -180,6 +176,10 @@ class MyGrowattTL3sDevice extends Growatt {
     }
   }
 
+  private getEffectiveMaxPower(): number {
+    return Number(this.getSetting('maxpeakpower')) || 6000;
+  }
+
   private getRegisterAddressForCapability(capability: string): number | undefined {
     const result = this.getMappingAndRegister(capability, this.holdingRegistersTLS);
     if (!result) return undefined;
@@ -190,7 +190,7 @@ class MyGrowattTL3sDevice extends Growatt {
     return this.processRegisterValueCommon(capability, registerValue, this.holdingRegistersTLS);
   }
 
-  async updateControl(type: string, value: number) {
+  async updateControl(type: string, value: number) {    
     const socket = new net.Socket();
     const unitID = this.getSetting('id');
     const client = new Modbus.client.TCP(socket, unitID, 2000);
@@ -227,9 +227,11 @@ class MyGrowattTL3sDevice extends Growatt {
           res = await client.writeSingleRegister(registerAddress, regValue);
           this.log(type, res);
           // Update the changed capability value
-          const typedValue = this.castToCapabilityType(type, value);
-          this.log(`typeof typedValue: ${typeof typedValue}, value:`, typedValue);
-          await this.setCapabilityValue(type, typedValue);
+          if (type !== 'target_power') {
+            const typedValue = this.castToCapabilityType(type, value);
+            this.log(`typeof typedValue: ${typeof typedValue}, value:`, typedValue);
+            await this.setCapabilityValue(type, typedValue);
+          }
         }
         this.log('disconnect');
         client.socket.end();
@@ -279,12 +281,21 @@ class MyGrowattTL3sDevice extends Growatt {
         client.socket.end();
         socket.end();
         const finalRes = { ...checkRegisterRes, ...checkHoldingRegisterRes };
-        if (Number(finalRes.inverterFaultBits?.value) !== 0) {
-          await this.setWarning(`Inverter fault active (code: ${finalRes.inverterFaultBits?.value})`);
+        if (finalRes.inverterFaultBits && Number(finalRes.inverterFaultBits.value) !== 0) {
+          await this.setWarning(`Inverter fault active (code: ${finalRes.inverterFaultBits.value})`);
         } else {
           await this.unsetWarning();
         }   
-        this.processResult(finalRes, this.getSetting('maxpeakpower'));
+        const maxpeakpower = Number(this.getSetting('maxpeakpower'));
+        this.processResult(finalRes, maxpeakpower);
+        if (finalRes.activePRate && maxpeakpower > 0 && this.hasCapability('target_power')) {
+          const pct = Number(finalRes.activePRate.value);
+          if (pct >= 0 && pct <= 100) {
+            const watts = Math.round((pct / 100) * maxpeakpower);
+            await this.setCapabilityValue('target_power', watts);
+            await this.setCapabilityValue('exportcapacity', watts);
+          }
+        }
       })().catch(this.error);
     });
 

--- a/drivers/growatt_tls/driver.compose.json
+++ b/drivers/growatt_tls/driver.compose.json
@@ -32,6 +32,7 @@
     "exportlimitenabled",
     "exportlimitpowerrate",
     "exportcapacity",
+    "target_power",
     "growattstatus"
   ],
   "capabilitiesOptions": {

--- a/drivers/growatt_tls/driver.ts
+++ b/drivers/growatt_tls/driver.ts
@@ -37,7 +37,9 @@ class MyGrowattTL3sDriver extends Homey.Driver {
 
     const exportcapacityAction = this.homey.flow.getActionCard('exportcapacity');
     exportcapacityAction.registerRunListener(async (args, state) => {
-      await args.device.updateControl('exportcapacity', args.percentage);
+      const maxpeakpower = Number(args.device.getSetting('maxpeakpower'));
+      await args.device.updateControl('target_power', args.percentage);
+      await args.device.setCapabilityValue('exportcapacity', Math.round((args.percentage / 100) * maxpeakpower));
     });
   }
 


### PR DESCRIPTION
Hi Edwin,

I've created this pull request because I added the target_power capacity which replaces the custom exportcapacity capability to set a Power Limit. This new capability requires Homey firmware 12.13.0 so I also raised the compatibility in app.json to >= 12.13.0.

I've rewritten the flowcard for export capacity so it now sets the target_power so the card keeps working, but I declared it deprecated so it can't be added in a new flow.

I've also changed the actual export capacity from percentage to power so you see a meaningful value there.

One other thing, there is no TL3-S Growatt with battery options so I did not change the growattwithbatt_tls device, just the growatt_tls device. I think the growattwithbatt_tls could even be removed, but I leave that up to you to decide.

If you have any questions, just let me know.

Cheers,

Danee