### PR TITLE
Add panels-only solar power for SolarEdge battery systems

### DIFF
--- a/app.json
+++ b/app.json
@@ -8346,6 +8346,7 @@
       "capabilities": [
         "measure_battery",
         "measure_power",
+        "measure_power.pv",
         "measure_power.import",
         "measure_power.export",
         "measure_power.batt_charge",
@@ -8402,6 +8403,15 @@
           "title": {
             "en": "Solar + Batt Power",
             "de": "Solar- und Batterie-Leistung"
+          }
+        },
+        "measure_power.pv": {
+          "decimals": 0,
+          "title": {
+            "en": "Solar Power (Panels Only)",
+            "nl": "Zonnepaneelvermogen",
+            "de": "PV-Modulleistung",
+            "pl": "Moc paneli PV"
           }
         },
         "measure_current.phase1": {

--- a/drivers/invertorwithbatt/device.ts
+++ b/drivers/invertorwithbatt/device.ts
@@ -15,6 +15,10 @@ class MySolaredgeBatteryDevice extends Solaredge {
   async onInit() {
     this.log('MySolaredgeBatteryDevice has been initialized');
 
+    if (this.hasCapability('measure_power.pv') === false) {
+      await this.addCapability('measure_power.pv');
+    }
+
     const name = this.getData().id;
     this.log(`device name id ${name}`);
     this.log(`device name ${this.getName()}`);

--- a/drivers/invertorwithbatt/driver.compose.json
+++ b/drivers/invertorwithbatt/driver.compose.json
@@ -14,6 +14,7 @@
   "capabilities": [
     "measure_battery",
     "measure_power",
+    "measure_power.pv",
     "measure_power.import",
     "measure_power.export",
     "measure_power.batt_charge",
@@ -70,6 +71,15 @@
       "title": {
         "en": "Solar + Batt Power",
         "de": "Solar- und Batterie-Leistung"
+      }
+    },
+    "measure_power.pv": {
+      "decimals": 0,
+      "title": {
+        "en": "Solar Power (Panels Only)",
+        "nl": "Zonnepaneelvermogen",
+        "de": "PV-Modulleistung",
+        "pl": "Moc paneli PV"
       }
     },
     "measure_current.phase1": {

--- a/drivers/solar-power.ts
+++ b/drivers/solar-power.ts
@@ -1,0 +1,19 @@
+export default function calculateSolarPanelPower(
+  inverterDcPower: number,
+  inverterAcPower: number | undefined,
+  batteryPowers: number[],
+): number {
+  const batteryPower = batteryPowers.reduce((total, power) => total + power, 0);
+
+  // Some inverter firmware does not expose reverse DC power while charging the
+  // battery from AC. In that case, use the signed AC power to remove the grid
+  // contribution from the signed battery charging power.
+  const inverterPower = batteryPower > 0
+    && inverterDcPower >= 0
+    && inverterAcPower !== undefined
+    && inverterAcPower < 0
+    ? inverterAcPower
+    : inverterDcPower;
+
+  return Math.max(0, Math.round(inverterPower + batteryPower));
+}

--- a/drivers/solaredge.ts
+++ b/drivers/solaredge.ts
@@ -1,4 +1,5 @@
 import Homey, { Device } from 'homey';
+import calculateSolarPanelPower from './solar-power';
 
 export interface Measurement {
   value: string;
@@ -262,6 +263,45 @@ export class Solaredge extends Homey.Device {
           console.log(`skip measure_power, max: ${maxpeakpower} power: ${acpower}`);
         } else {
           this.setCapabilityValue('measure_power', Math.round(acpower));
+        }
+      }
+
+      const dcPowerRecord = result['power_dc'];
+      const acPowerRecord = result['power_ac'];
+      const battery1PowerRecord = result['batt1-instantaneous_power'];
+      const battery2PowerRecord = result['batt2-instantaneous_power'];
+
+      if (
+        dcPowerRecord
+        && dcPowerRecord.value !== 'xxx'
+        && dcPowerRecord.scale !== 'xxx'
+        && battery1PowerRecord
+        && battery1PowerRecord.value !== 'xxx'
+      ) {
+        const dcPower = Number(dcPowerRecord.value) * Math.pow(10, Number(dcPowerRecord.scale));
+        const acPower = acPowerRecord && acPowerRecord.value !== 'xxx' && acPowerRecord.scale !== 'xxx'
+          ? Number(acPowerRecord.value) * Math.pow(10, Number(acPowerRecord.scale))
+          : undefined;
+        const batteryPowers = [Number(battery1PowerRecord.value)];
+
+        if (battery2PowerRecord?.value !== undefined && battery2PowerRecord.value !== 'xxx') {
+          batteryPowers.push(Number(battery2PowerRecord.value));
+        }
+
+        if (
+          Number.isFinite(dcPower)
+          && (acPower === undefined || Number.isFinite(acPower))
+          && batteryPowers.every((power) => Number.isFinite(power))
+        ) {
+          const solarPower = calculateSolarPanelPower(dcPower, acPower, batteryPowers);
+
+          if (this.hasCapability('measure_power.pv') === false) {
+            await this.addCapability('measure_power.pv');
+          }
+
+          if (maxpeakpower <= 0 || solarPower <= maxpeakpower) {
+            await this.setCapabilityValue('measure_power.pv', solarPower);
+          }
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "clean": "del-cli ./.homeybuild/** ./node_modules/**",
     "format": "prettier --write .",
     "lint": "eslint --ext .js,.ts --ignore-path .gitignore .",
+    "test:solar-power": "npm run build && node .homeybuild/tests/solar-power.test.cjs",
     "validate": "homey app validate"
   },
   "devDependencies": {

--- a/tests/solar-power.test.cjs
+++ b/tests/solar-power.test.cjs
@@ -1,0 +1,75 @@
+const assert = require('node:assert/strict');
+const calculateSolarPanelPower = require('../drivers/solar-power').default;
+
+const cases = [
+  {
+    name: 'reports inverter DC power while the battery is idle',
+    dc: 3000,
+    ac: 2940,
+    batteries: [0],
+    expected: 3000,
+  },
+  {
+    name: 'includes PV routed directly into a charging battery',
+    dc: 0,
+    ac: 0,
+    batteries: [2000],
+    expected: 2000,
+  },
+  {
+    name: 'removes battery discharge from the inverter DC power',
+    dc: 2500,
+    ac: 2400,
+    batteries: [-2000],
+    expected: 500,
+  },
+  {
+    name: 'reports zero while only the battery supplies the inverter',
+    dc: 2000,
+    ac: 1900,
+    batteries: [-2000],
+    expected: 0,
+  },
+  {
+    name: 'removes grid power used to charge the battery',
+    dc: -1500,
+    ac: -1400,
+    batteries: [3000],
+    expected: 1500,
+  },
+  {
+    name: 'uses AC fallback when reverse DC power is not reported',
+    dc: 0,
+    ac: -1500,
+    batteries: [3000],
+    expected: 1500,
+  },
+  {
+    name: 'does not report grid-only battery charging as solar power',
+    dc: 0,
+    ac: -3100,
+    batteries: [3000],
+    expected: 0,
+  },
+  {
+    name: 'supports two charging batteries',
+    dc: 1000,
+    ac: 980,
+    batteries: [1200, 800],
+    expected: 3000,
+  },
+  {
+    name: 'clamps conversion-loss differences to zero',
+    dc: 1950,
+    ac: 1900,
+    batteries: [-2000],
+    expected: 0,
+  },
+];
+
+for (const testCase of cases) {
+  const actual = calculateSolarPanelPower(testCase.dc, testCase.ac, testCase.batteries);
+  assert.equal(actual, testCase.expected, testCase.name);
+}
+
+console.log(`Solar power calculation: ${cases.length} scenarios passed`);


### PR DESCRIPTION
## Overview

Adds a Solar Power (Panels Only) capability to the SolarEdge inverter-with-battery driver.

The existing Solar + Batt Power value is the inverter net AC output. It can read zero while PV is charging a DC-coupled battery and can include battery discharge, so it does not represent instantaneous panel generation.

## Calculation

The new capability reconstructs PV-only generation from signed DC flows:

PV power = max(inverter DC power + battery DC power, 0)

Positive battery power restores PV routed directly into storage; negative battery power removes battery-originated output. Both supported batteries are included. If a battery is charging from AC and firmware does not expose reverse DC power, signed inverter AC power is used as a fallback so grid charging is not counted as PV.

The existing Solar + Batt Power capability remains unchanged for backward compatibility.

## Validation

- Added 9 calculation scenarios covering idle, charging and discharging batteries, nighttime discharge, AC charging fallback, grid-only charging, conversion loss, and two batteries.
- npm run test:solar-power
- npm run build
- npm run validate (publish level)